### PR TITLE
Add support for registry.example.com:5000

### DIFF
--- a/docker_reg_tool
+++ b/docker_reg_tool
@@ -68,7 +68,7 @@ CREDS=""
 DOCKER_CONFIG="$HOME/.docker/config.json"
 
 if [[ -f "$DOCKER_CONFIG" ]]; then
-    AUTH_INFO=$(jq -r '.auths."'$REG'".auth' < "$DOCKER_CONFIG")
+    AUTH_INFO=$(jq -r '.auths["'$REG'"].auth' < "$DOCKER_CONFIG")
     if [ "$AUTH_INFO" = "null" ]; then
         AUTH_INFO=$(jq -r '.auths."'$PROTO$REG'".auth' < "$DOCKER_CONFIG")
         if [ "$AUTH_INFO" = "null" ]; then


### PR DESCRIPTION
I got a syntax error from jq with a registry with a port number. This PR will fix the syntax issue.