### PR TITLE
oci manifest support

### DIFF
--- a/docker_reg_tool
+++ b/docker_reg_tool
@@ -109,7 +109,10 @@ case "$ACTION" in
         repo=$1
         tag=$2
         response=$(curlCmd -v -s -H "Accept:application/vnd.docker.distribution.manifest.v2+json" "$PROTO$REG/v2/$repo/manifests/$tag" 2>&1)
-        digest=$(echo "$response" | grep -i "< Docker-Content-Digest:"|awk '{print $3}')
+        digest=$(echo "$response" | grep -i "< Docker-Content-Digest:"|awk '{print $3}' || echo "")
+        [ -z "$digest" ] &&
+          response=$(curlCmd -v -s -H "Accept:application/vnd.oci.image.manifest.v1+json" "$PROTO$REG/v2/$repo/manifests/$tag" 2>&1) &&
+          digest=$(echo "$response" | grep -i "< Docker-Content-Digest:"|awk '{print $3}')
         digest=${digest//[$'\t\r\n']}
         echo "DIGEST: $digest"
         result=$(curlCmd -s -o /dev/null -w "%{http_code}" -H "Accept:application/vnd.docker.distribution.manifest.v2+json" -X DELETE "$PROTO$REG/v2/$repo/manifests/$digest")


### PR DESCRIPTION
In my private repo I have some OCI images that delete was refusing to work with. I found it was simply an accept header thing, so I added a fallback from the first check to accept OCI instead (I don't trust docker private registries to be smart enough to understand multiple Accept headers, though I could be wrong). This tweak does the trick for me.